### PR TITLE
Original filename

### DIFF
--- a/mnamer/metadata.py
+++ b/mnamer/metadata.py
@@ -44,6 +44,7 @@ class Metadata:
     language_sub: Language | None = None
     quality: str | None = None
     synopsis: str | None = None
+    original_filename: str | None = None
 
     @classmethod
     def to_media_type(cls) -> MediaType:

--- a/mnamer/setting_store.py
+++ b/mnamer/setting_store.py
@@ -322,7 +322,7 @@ class SettingStore:
         default=False,
         metadata=SettingSpec(
             action="store_true",
-            flags=["--test"],
+            flags=["--test", "--dry-run", "--dryrun"],
             group=SettingType.DIRECTIVE,
             help="--test: mocks the renaming and moving of files",
         ).as_dict(),

--- a/mnamer/target.py
+++ b/mnamer/target.py
@@ -148,6 +148,7 @@ class Target:
             None: Metadata,
         }[media_type]
         self.metadata = meta_cls()
+        self.metadata.original_filename = self.source.name
         self.metadata.quality = (
             " ".join(
                 path_data[key]

--- a/tests/e2e/test_moving.py
+++ b/tests/e2e/test_moving.py
@@ -211,3 +211,15 @@ def test_ambiguous_language_deletction(e2e_run, setup_test_files):
     )
     result = e2e_run("--batch", ".")
     assert result.code == 0
+
+
+@pytest.mark.usefixtures("setup_test_dir")
+def test_original_filename(e2e_run, setup_test_files):
+    setup_test_files("archer.2009.s10e07.webrip.x264-lucidtv.mp4")
+    result = e2e_run(
+        "--batch",
+        "--episode-format='{original_filename}'",
+        ".",
+    )
+    assert result.code == 0
+    assert "archer.2009.s10e07.webrip.x264-lucidtv.mp4" in result.out


### PR DESCRIPTION
Adds the option to use original filename as field variables {original_filename} 